### PR TITLE
client: Store boolean in window for the RxPlayer

### DIFF
--- a/client/src/client.js
+++ b/client/src/client.js
@@ -420,6 +420,7 @@ const __TOKEN__ = "";
     }
     return processed;
   }
+  window.__RX_PLAYER_DEBUG_MODE__ = true;
 })();
 
 function evaluate(obj){


### PR DESCRIPTION
This commit adds a `__Rx_PLAYER_DEBUG_MODE__` boolean to `true` in
`window`, so the RxPlayer can then read it and put iself in a `"DEBUG"`
LogLevel (and perhaps other things in the future) when it is present.

This allows to simplify the usage of RxPaired to debug the RxPlayer in
various applications: it will become unnecessary to also have to raise
log verbosity manually, the only action will be to deploy the client
script on the device.

I'm also doing a Pull Request on the RxPlayer